### PR TITLE
http -> https so demos work on Chromium browsers (Fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bower install threex.webar
 ```
 
 # How To Run The Demo ?
-- put a browser on http://jeromeetienne.github.io/threex.webar/examples/basic.html
+- put a browser on https://jeromeetienne.github.io/threex.webar/examples/basic.html
 - it will read your webcam using [getUserMedia](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia)
   - if it asks for permission, allow it :)
 - it will recognize the marker you put in front of the mcamera
@@ -47,17 +47,17 @@ and
   for [getUserMedia](http://caniuse.com/#feat=stream), so iphone and ipads can't play :(
 
 # Show Don't Tell
-* [examples/basic.html](http://jeromeetienne.github.io/threex.webar/examples/basic.html)
+* [examples/basic.html](https://jeromeetienne.github.io/threex.webar/examples/basic.html)
 \[[view source](https://github.com/jeromeetienne/threex.webar/blob/master/examples/basic.html)\] :
 It shows a basic augmented reality webapp. Good to learn how to use the code. Perfect start point.
 -
 [youtube video](https://www.youtube.com/watch?v=fz9bmOfYvG0)
-* [examples/data-visualization-histogram3d.html](http://jeromeetienne.github.io/threex.webar/examples/data-visualization-histogram3d.html)
+* [examples/data-visualization-histogram3d.html](https://jeromeetienne.github.io/threex.webar/examples/data-visualization-histogram3d.html)
 \[[view source](https://github.com/jeromeetienne/threex.webar/blob/master/examples/data-visualization-histogram3d.html)\] :
 It shows a possible data visualisation with 3d histogram. You can change the value the way you like. You can get them from a REST API, or from an industrial sensor, what ever you want.
 -
 [vine video](https://vine.co/v/ei1TDWLrYiX)
-* [examples/contact-sharing-in-ar.html](http://jeromeetienne.github.io/threex.webar/examples/contact-sharing-in-ar.html)
+* [examples/contact-sharing-in-ar.html](https://jeromeetienne.github.io/threex.webar/examples/contact-sharing-in-ar.html)
 \[[view source](https://github.com/jeromeetienne/threex.webar/blob/master/examples/contact-sharing-in-ar.html)\] :
 It shows how to display informations on a per-marker basis.
 There is a database which contains the informations. When the proper marker is recognized, the info specific to this marker is displayed. In this example, we provide a contact sharing webapp. Everybody got his own marker. Suppose alice wears a specific marker. Bob load the apps on his mobile, and will see alice contact information when he point it to alice.


### PR DESCRIPTION
Make http links to demos https so demos work on Chromium browsers due to:
https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features
