### PR TITLE
Fix: MediaStreamTrack.getSources

### DIFF
--- a/threex.webcamgrabbing.js
+++ b/threex.webcamgrabbing.js
@@ -77,7 +77,7 @@ THREEx.WebcamGrabbing = function(){
         }, 500)
 
         // get the media sources
-        MediaStreamTrack.getSources(function(sourceInfos) {
+        navigator.mediaDevices.enumerateDevices().then(function(sourceInfos) {
                 // define getUserMedia() constraints
                 var constraints = {
                         video: true,


### PR DESCRIPTION
_MediaStreamTrack.getSources()_ was deprecated and then removed: using it causes the
error "MediaStreamTrack.getSources is not a function"

Replacing it with _navigator.mediaDevices.enumerateDevices()_ fixes the problem.

See https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
